### PR TITLE
Fix server URLs in `openapi.json`

### DIFF
--- a/pkg/api_client/routers.go
+++ b/pkg/api_client/routers.go
@@ -42,11 +42,11 @@ func NewRouter(apiVersion string, controller *handler.APIsAPIController) *fizz.F
 
 	f.Generator().SetServers([]*openapi.Server{
 		{
-			URL:         "https://api.developer.overheid.nl/api-register/v1",
+			URL:         "https://api.developer.overheid.nl/api-register",
 			Description: "Production",
 		},
 		{
-			URL:         "https://api-register.don.apps.digilab.network/api-register/v1",
+			URL:         "https://api.don.apps.digilab.network/api-register",
 			Description: "Test",
 		},
 	})


### PR DESCRIPTION
The version number was duplicated between the server URL and the paths (since the paths already list the major version number). Also the test server address is `api.don` instead of `api-register.don`.